### PR TITLE
Fix gows

### DIFF
--- a/gows/main.go
+++ b/gows/main.go
@@ -5,14 +5,15 @@ import (
 	"io/ioutil"
 	"log"
 	"net/http"
+	"sync/atomic"
 	"time"
 )
 
 func main() {
-	var count = 0
+	var count int32 = 0
 	// set router
 	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
-		count++
+		atomic.AddInt32(&count, 1)
 		handleConnection(w, count)
 	})
 	// set listen port
@@ -22,7 +23,7 @@ func main() {
 	}
 }
 
-func handleConnection(w http.ResponseWriter, count int) {
+func handleConnection(w http.ResponseWriter, count int32) {
 	// add 2 second delay to every 10th request
 	if (count % 10) == 0 {
 		println("Adding delay. Count: ", count)

--- a/gows/main.go
+++ b/gows/main.go
@@ -29,7 +29,11 @@ func handleConnection(w http.ResponseWriter, count int32) {
 		println("Adding delay. Count: ", count)
 		time.Sleep(2 * time.Second)
 	}
-	html, _ := ioutil.ReadFile("hello.html") // read html file
+	html, err := ioutil.ReadFile("hello.html") // read html file
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
 	w.Header().Add("Connection", "keep-alive")
 	w.WriteHeader(200)           // 200 OK
 	fmt.Fprintf(w, string(html)) // send data to client side

--- a/gows/main.go
+++ b/gows/main.go
@@ -34,7 +34,6 @@ func handleConnection(w http.ResponseWriter, count int32) {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
-	w.Header().Add("Connection", "keep-alive")
 	w.WriteHeader(200)           // 200 OK
 	fmt.Fprintf(w, string(html)) // send data to client side
 }

--- a/gows/main.go
+++ b/gows/main.go
@@ -13,8 +13,7 @@ func main() {
 	var count int32 = 0
 	// set router
 	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
-		atomic.AddInt32(&count, 1)
-		handleConnection(w, count)
+		handleConnection(w, atomic.AddInt32(&count, 1))
 	})
 	// set listen port
 	err := http.ListenAndServe(":8080", nil)

--- a/gows/main.go
+++ b/gows/main.go
@@ -12,7 +12,6 @@ func main() {
 	var count = 0
 	// set router
 	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
-		defer r.Body.Close()
 		count++
 		handleConnection(w, count)
 	})


### PR DESCRIPTION
* do not need to close req.Body manually. It will close by server.
* use atomic.AddInt32 since it may be race condition
* return error if the file can not be read.

The third change might make gows be slowly but other languages possibly handle exception. So gows have to check the error for the fair.