### PR TITLE
Remove async keyword

### DIFF
--- a/dotnetws/Program.cs
+++ b/dotnetws/Program.cs
@@ -1,14 +1,5 @@
 var app = WebApplication.CreateBuilder(args).Build();
 
-app.MapGet("/", async () =>
-{
-    return Results.Text("Hello", "text/html");
-});
-
-// Sync version
-// app.MapGet("/", () => 
-// {
-//     return Results.Text("Hello", "text/html");
-// });
+app.MapGet("/", () => Results.Text("Hello", "text/html"));
 
 app.Run();


### PR DESCRIPTION
Just a small correction to avoid confusing people that may look at the code.

The `async` keyword is not useful in this case because there is no `await` operator. At a lower level, It is even a bit counterproductive because the compiler will create a state machine to handle the `async` method, making it more complex and adding memory allocations.

In the current state, the compiler emits a warning 
> warning CS1998: This async method lacks 'await' operators and will run synchronously. Consider using the 'await' operator to await non-blocking API calls, or 'await Task.Run(...)' to do CPU-bound work on a background thread

As a visual example, you can check this TS example and try to remove the `async` keyword (I don't know how close it is, but I think the idea is more or less the same) https://www.typescriptlang.org/play?target=1&ssl=1&ssc=35&pln=1&pc=1#code/MYewdgzgLgBAtgTwGIFczBgXhgQwg9GACgEosA+GAIgAsBTAGwZCqA